### PR TITLE
feat: Add RHI pipeline states and render pass interfaces

### DIFF
--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -1,6 +1,6 @@
 import { EventDispatcher } from './base/eventDispatcher';
 import { Container, ServiceKeys } from './base/IOC';
-import { Time } from './base/Time';
+import { Time } from './base/time';
 import { Scene } from './scene/Scene';
 import { SceneManager } from './scene/SceneManager';
 import { ResourceManager } from './resource/ResourceManager';

--- a/packages/core/src/base/ObjectPoolManager.ts
+++ b/packages/core/src/base/ObjectPoolManager.ts
@@ -1,5 +1,5 @@
 import { ObjectPool } from './ObjectPool';
-import { Time } from './Time';
+import { Time } from './time';
 import { EventDispatcher } from './eventDispatcher';
 
 /**

--- a/packages/core/src/base/Time.ts
+++ b/packages/core/src/base/Time.ts
@@ -3,27 +3,27 @@
  */
 export class Time {
   /** 当前时间（秒） */
-  private _time: number = 0;
+  protected time: number = 0;
   /** 上一帧时间（秒） */
-  private _lastTime: number = 0;
+  protected lastTime: number = 0;
   /** 引擎启动以来经过的总秒数 */
-  private _sinceStartup: number = 0;
+  protected sinceStartup: number = 0;
   /** 自上一帧以来经过的秒数 */
-  private _deltaTime: number = 0;
+  deltaTime: number = 0;
   /** 未受缩放影响的deltaTime */
-  private _unscaledDeltaTime: number = 0;
+  protected unscaledDeltaTime: number = 0;
   /** 时间缩放系数 */
-  private _timeScale: number = 1.0;
+  timeScale: number = 1.0;
   /** 帧数计数 */
-  private _frameCount: number = 0;
+  protected frameCount: number = 0;
   /** 固定时间步长（秒） */
-  private _fixedDeltaTime: number = 0.02; // 默认50Hz
+  fixedDeltaTime: number = 0.02; // 默认50Hz
   /** 最大允许的时间步长（秒） */
-  private _maximumDeltaTime: number = 0.3333333; // 默认最低3FPS
+  maximumDeltaTime: number = 0.3333333; // 默认最低3FPS
   /** 固定更新累积器 */
-  private _fixedTimeAccumulator: number = 0;
+  fixedTimeAccumulator: number = 0;
   /** 上一次实际更新时间（毫秒） */
-  private _lastRealTimestamp: number = 0;
+  lastRealTimestamp: number = 0;
 
   /**
    * 创建时间管理器
@@ -38,14 +38,14 @@ export class Time {
   reset (): void {
     const now = performance.now() / 1000; // 转换为秒
 
-    this._time = now;
-    this._lastTime = now;
-    this._sinceStartup = 0;
-    this._deltaTime = 0;
-    this._unscaledDeltaTime = 0;
-    this._frameCount = 0;
-    this._fixedTimeAccumulator = 0;
-    this._lastRealTimestamp = now;
+    this.time = now;
+    this.lastTime = now;
+    this.sinceStartup = 0;
+    this.deltaTime = 0;
+    this.unscaledDeltaTime = 0;
+    this.frameCount = 0;
+    this.fixedTimeAccumulator = 0;
+    this.lastRealTimestamp = now;
   }
 
   /**
@@ -53,103 +53,26 @@ export class Time {
    */
   update (): void {
     const now = performance.now() / 1000; // 转换为秒
-    const realDeltaTime = now - this._lastTime;
+    const realDeltaTime = now - this.lastTime;
 
     // 限制最大时间步长
-    this._unscaledDeltaTime = Math.min(realDeltaTime, this._maximumDeltaTime);
+    this.unscaledDeltaTime = Math.min(realDeltaTime, this.maximumDeltaTime);
 
     // 应用时间缩放
-    this._deltaTime = this._unscaledDeltaTime * this._timeScale;
+    this.deltaTime = this.unscaledDeltaTime * this.timeScale;
 
     // 更新时间
-    this._time += this._deltaTime;
-    this._sinceStartup += this._unscaledDeltaTime;
+    this.time += this.deltaTime;
+    this.sinceStartup += this.unscaledDeltaTime;
 
     // 更新上一帧时间
-    this._lastTime = now;
+    this.lastTime = now;
 
     // 更新帧数
-    this._frameCount++;
+    this.frameCount++;
 
     // 更新固定时间步长累积器
-    this._fixedTimeAccumulator += this._deltaTime;
-  }
-
-  /**
-   * 获取当前时间（秒）
-   */
-  get time (): number {
-    return this._time;
-  }
-
-  /**
-   * 获取自引擎启动以来经过的总秒数
-   */
-  get sinceStartup (): number {
-    return this._sinceStartup;
-  }
-
-  /**
-   * 获取自上一帧以来经过的秒数
-   */
-  get deltaTime (): number {
-    return this._deltaTime;
-  }
-
-  /**
-   * 获取未受缩放影响的deltaTime
-   */
-  get unscaledDeltaTime (): number {
-    return this._unscaledDeltaTime;
-  }
-
-  /**
-   * 获取时间缩放系数
-   */
-  get timeScale (): number {
-    return this._timeScale;
-  }
-
-  /**
-   * 设置时间缩放系数
-   */
-  set timeScale (value: number) {
-    this._timeScale = Math.max(0, value);
-  }
-
-  /**
-   * 获取帧数计数
-   */
-  get frameCount (): number {
-    return this._frameCount;
-  }
-
-  /**
-   * 获取固定时间步长（秒）
-   */
-  get fixedDeltaTime (): number {
-    return this._fixedDeltaTime;
-  }
-
-  /**
-   * 设置固定时间步长（秒）
-   */
-  set fixedDeltaTime (value: number) {
-    this._fixedDeltaTime = Math.max(0.0001, value);
-  }
-
-  /**
-   * 获取最大允许的时间步长（秒）
-   */
-  get maximumDeltaTime (): number {
-    return this._maximumDeltaTime;
-  }
-
-  /**
-   * 设置最大允许的时间步长（秒）
-   */
-  set maximumDeltaTime (value: number) {
-    this._maximumDeltaTime = Math.max(0.0001, value);
+    this.fixedTimeAccumulator += this.deltaTime;
   }
 
   /**
@@ -157,13 +80,13 @@ export class Time {
    * @returns 是否需要固定更新
    */
   needFixedUpdate (): boolean {
-    return this._fixedTimeAccumulator >= this._fixedDeltaTime;
+    return this.fixedTimeAccumulator >= this.fixedDeltaTime;
   }
 
   /**
    * 执行固定更新
    */
   performFixedUpdate (): void {
-    this._fixedTimeAccumulator -= this._fixedDeltaTime;
+    this.fixedTimeAccumulator -= this.fixedDeltaTime;
   }
 }

--- a/packages/core/src/base/index.ts
+++ b/packages/core/src/base/index.ts
@@ -5,7 +5,7 @@ export * from './entity';
 export * from './component';
 export * from './transform';
 export * from './canvas';
-export * from './Time';
+export * from './time';
 export * from './ObjectPool';
 export * from './ObjectPoolManager';
 export * from './ReferResource';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,13 +31,7 @@ export * from './utils';
 export * from './interface';
 
 // 基础组件
-export * from './base/event';
-export * from './base/eventDispatcher';
-export * from './base/canvas';
-export * from './base/Time';
-export * from './base/ObjectPool';
-export * from './base/ObjectPoolManager';
-export * from './base/eventDispatcher';
+export * from './base';
 
 // 场景组件
 export * from './scene/Scene';
@@ -84,9 +78,6 @@ export * from './camera/Camera';
 // 光照系统
 export * from './light/Light';
 
-// 接口定义
-export * from './interface/IHardwareRenderer';
-
 // 序列化系统
 export * from './serialization/Serialization';
 
@@ -99,4 +90,6 @@ export * from './input/InputCode';
 export * from './input/InputState';
 
 // 导出数学库类型
-export type { Vector2, Vector3, Vector4, Matrix3, Matrix4, Quaternion, Color } from '@maxellabs/math';
+export * from '@maxellabs/math';
+// 导出规范库
+export * from '@maxellabs/specification';

--- a/packages/core/src/interface/IGraphicsDevice.ts
+++ b/packages/core/src/interface/IGraphicsDevice.ts
@@ -1,0 +1,201 @@
+import type { Color } from '@maxellabs/math';
+import type {
+  BufferInfo,
+  IBuffer,
+  TextureInfo,
+  ITexture,
+  SamplerInfo,
+  ISampler,
+  ShaderInfo,
+  IShader,
+  RenderTargetInfo,
+  IRenderTarget,
+  PipelineStateInfo,
+  IPipelineState,
+  IndexFormat,
+  PrimitiveType,
+  RenderPassDescriptor,
+  // GraphicsFeature, // Assuming GraphicsFeature is specific to IGraphicsDevice or engine capabilities rather than pure RHI
+} from './rhi'; // Import from the new RHI entry point
+
+/**
+ * 图形设备能力标志 - 移至此处或引擎特定能力文件中，而非RHI层
+ */
+export enum GraphicsFeature {
+  INSTANCING = 'instancing',
+  MULTIPLE_RENDER_TARGETS = 'multipleRenderTargets',
+  DEPTH_TEXTURE = 'depthTexture',
+  FLOAT_TEXTURE = 'floatTexture',
+  HALF_FLOAT_TEXTURE = 'halfFloatTexture',
+  ANISOTROPIC_FILTERING = 'anisotropicFiltering',
+  VERTEX_ARRAY_OBJECT = 'vertexArrayObject',
+  S3TC_TEXTURE_COMPRESSION = 's3tcTextureCompression',
+  ASTC_TEXTURE_COMPRESSION = 'astcTextureCompression',
+  ETC2_TEXTURE_COMPRESSION = 'etc2TextureCompression',
+  COMPUTE_SHADER = 'computeShader',
+  TEXTURE_FORMAT_BC1 = 'texture-format-bc1',
+  TEXTURE_FORMAT_BC2 = 'texture-format-bc2',
+  TEXTURE_FORMAT_BC3 = 'texture-format-bc3',
+  TEXTURE_FORMAT_BC4 = 'texture-format-bc4',
+  TEXTURE_FORMAT_BC5 = 'texture-format-bc5',
+  TEXTURE_FORMAT_BC6H = 'texture-format-bc6h',
+  TEXTURE_FORMAT_BC7 = 'texture-format-bc7',
+  TEXTURE_FORMAT_ETC2 = 'texture-format-etc2',
+  TEXTURE_FORMAT_ASTC = 'texture-format-astc',
+  TIMESTAMP_QUERY = 'timestamp-query',
+  PIPELINE_STATISTICS_QUERY = 'pipeline-statistics-query',
+  INDIRECT_FIRST_INSTANCE = 'indirect-first-instance',
+  SHADER_FLOAT64 = 'shader-float64',
+  SHADER_INT16 = 'shader-int16',
+  SHADER_INT64 = 'shader-int64',
+  // ... 更多特性
+}
+
+/**
+ * 图形设备能力信息
+ */
+export interface IGraphicsDeviceCapabilities {
+  readonly maxTextureDimension1D: number;
+  readonly maxTextureDimension2D: number;
+  readonly maxTextureDimension3D: number;
+  readonly maxTextureArrayLayers: number;
+  readonly maxBindGroups: number;
+  readonly maxDynamicUniformBuffersPerPipelineLayout: number;
+  readonly maxDynamicStorageBuffersPerPipelineLayout: number;
+  readonly maxSampledTexturesPerShaderStage: number;
+  readonly maxSamplersPerShaderStage: number;
+  readonly maxStorageBuffersPerShaderStage: number;
+  readonly maxStorageTexturesPerShaderStage: number;
+  readonly maxUniformBuffersPerShaderStage: number;
+  readonly maxUniformBufferBindingSize: number;
+  readonly maxStorageBufferBindingSize: number;
+  readonly minUniformBufferOffsetAlignment: number;
+  readonly minStorageBufferOffsetAlignment: number;
+  readonly maxVertexBuffers: number;
+  readonly maxVertexAttributes: number;
+  readonly maxVertexBufferArrayStride: number;
+  readonly maxColorAttachments: number;
+  readonly maxColorAttachmentBytesPerSample: number;
+
+  isFeatureSupported(feature: GraphicsFeature): boolean;
+  isTextureFormatSupported(format: import('./rhi').TextureFormat): boolean; 
+}
+
+/**
+ * 图形设备初始化选项
+ */
+export interface GraphicsDeviceOptions {
+  alpha?: boolean;
+  antialias?: boolean;
+  depth?: boolean;
+  stencil?: boolean;
+  preserveDrawingBuffer?: boolean;
+  powerPreference?: 'default' | 'high-performance' | 'low-power';
+  pixelRatio?: number;
+  requiredFeatures?: GraphicsFeature[];
+  requiredLimits?: Partial<Record<keyof Omit<IGraphicsDeviceCapabilities, 'isFeatureSupported' | 'isTextureFormatSupported'>, number>>;
+}
+
+export interface IRenderPassEncoder {
+  setPipeline(pipeline: IPipelineState): void;
+  setVertexBuffer(slot: number, buffer: IBuffer, offset?: number, size?: number): void;
+  setIndexBuffer(buffer: IBuffer, indexFormat: IndexFormat, offset?: number, size?: number): void;
+  // Bind group related methods for WebGPU style, or individual resource binding for WebGL
+  setBindGroup(index: number, bindGroup: any /*IBindGroup*/, dynamicOffsets?: number[]): void;
+  // Or more WebGL-like direct bindings if abstracting over WebGL directly without full bind group emulation
+  setUniformBuffer(slot: number, buffer: IBuffer, offset?: number, size?: number): void;
+  setTextureView(slot: number, view: import('./rhi').ITextureView): void;
+  setSampler(slot: number, sampler: ISampler): void;
+  
+  draw(vertexCount: number, instanceCount?: number, firstVertex?: number, firstInstance?: number): void;
+  drawIndexed(indexCount: number, instanceCount?: number, firstIndex?: number, baseVertex?: number, firstInstance?: number): void;
+  drawIndirect(indirectBuffer: IBuffer, indirectOffset: number): void;
+  drawIndexedIndirect(indirectBuffer: IBuffer, indirectOffset: number): void;
+  
+  // Render pass specific commands
+  setViewport(x: number, y: number, width: number, height: number, minDepth?: number, maxDepth?: number): void;
+  setScissorRect(x: number, y: number, width: number, height: number): void;
+  setBlendConstant(color: Color | [number,number,number,number]): void;
+  setStencilReference(reference: number): void;
+  
+  beginOcclusionQuery?(queryIndex: number): void;
+  endOcclusionQuery?(): void;
+  executeBundles?(bundles: any[] /*IRenderBundle[]*/): void;
+  pushDebugGroup?(groupLabel: string): void;
+  popDebugGroup?(): void;
+  insertDebugMarker?(markerLabel: string): void;
+  
+  end(): void;
+}
+
+/**
+ * 底层图形设备接口 (Rendering Hardware Interface - RHI)
+ */
+export interface IGraphicsDevice {
+  readonly canvas?: HTMLCanvasElement;
+  readonly drawingBufferWidth: number;
+  readonly drawingBufferHeight: number;
+  readonly pixelRatio: number;
+  readonly capabilities: IGraphicsDeviceCapabilities;
+  readonly isInitialized: boolean;
+  readonly lost?: Promise<any /* GPUDeviceLostInfo */>; // For WebGPU device loss
+  readonly name: string; // e.g. 'WebGL 2.0', 'WebGPU - Intel Iris Plus Graphics'
+
+  initialize(canvas: HTMLCanvasElement, options?: GraphicsDeviceOptions): Promise<boolean>;
+  destroy(): void;
+
+  beginFrame(): void; // May not be needed for all backends
+  endFrame(): void;   // Presents the frame
+
+  // Resource Creation
+  createBuffer(descriptor: BufferInfo): IBuffer;
+  createTexture(descriptor: TextureInfo): ITexture;
+  createSampler(descriptor?: SamplerInfo): ISampler; // SamplerInfo is optional for default sampler
+  createShader(descriptor: ShaderInfo): IShader; // IShader might be more of a module container
+  createRenderTarget(descriptor: RenderTargetInfo): IRenderTarget; // Might be a helper for views
+  createPipelineState(descriptor: PipelineStateInfo): IPipelineState;
+  // createBindGroupLayout(descriptor: BindGroupLayoutInfo): IBindGroupLayout;
+  // createPipelineLayout(descriptor: PipelineLayoutInfo): IPipelineLayout;
+  // createBindGroup(descriptor: BindGroupInfo): IBindGroup;
+  // createComputePipeline(descriptor: ComputePipelineInfo): IComputePipelineState;
+  // createRenderBundleEncoder(descriptor: RenderBundleEncoderDescriptor): IRenderBundleEncoder;
+  // createQuerySet(descriptor: QuerySetDescriptor): IQuerySet;
+
+  // Resource Updates (simplified, specific updates might be on resources themselves or via command encoder)
+  updateBufferData(buffer: IBuffer, data: ArrayBufferView, bufferOffset?: number, dataOffset?: number, size?: number): void;
+  updateTextureData(
+    texture: ITexture,
+    source: TexImageSource | ArrayBufferView | ArrayBufferView[], // TexImageSource for WebGL, Buffer for WebGPU
+    destination?: {
+        origin?: [number, number, number], // x, y, z/layer
+        mipLevel?: number,
+    },
+    layout?: {
+        offset?: number, // Required if data is ArrayBufferView
+        bytesPerRow?: number, // Required if data is ArrayBufferView and rows > 1 or texture is 2D/3D
+        rowsPerImage?: number, // Required if data is ArrayBufferView and texture is 3D
+    },
+    size?: [number, number, number] // width, height, depth/layers
+  ): void;
+  
+  // Direct state setting (mostly for simpler APIs or initial setup, pass commands prefer encoder)
+  setViewport(x: number, y: number, width: number, height: number): void;
+  setScissor(x: number, y: number, width: number, height: number, enabled?: boolean): void;
+  clear(options: { color?: Color | [number,number,number,number] | false, depth?: number | false, stencil?: number | false }): void;
+
+  // Render Pass Management
+  beginRenderPass(descriptor: RenderPassDescriptor): IRenderPassEncoder;
+  // beginComputePass(descriptor?: ComputePassDescriptor): IComputePassEncoder;
+
+  // Command Submission (for backends that explicitly use queues/submission)
+  submit?(commandBuffers: any[] /*ICommandBuffer[]*/): void;
+
+  readPixels(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    sourceRenderTarget?: IRenderTarget | null, // null for default framebuffer
+    destinationBuffer?: Uint8Array // Optional pre-allocated buffer
+  ): Promise<Uint8Array>;
+}

--- a/packages/core/src/interface/IRenderPass.ts
+++ b/packages/core/src/interface/IRenderPass.ts
@@ -1,6 +1,27 @@
 import type { Scene } from '../scene/scene';
 import type { Camera } from '../camera/camera';
-import type { IRenderTarget } from './IRenderTarget';
+import type { IGraphicsDevice, IRenderPassEncoder } from './IGraphicsDevice';
+import type { RenderTargetInfo, RenderPassDescriptor, ITextureView } from './rhi';
+
+/**
+ * 渲染通道配置选项，用于在创建或执行时指定行为。
+ */
+export interface RenderPassExecutionOptions {
+  /**
+   * 覆盖此通道的默认渲染目标信息。
+   * 如果提供，通道将渲染到这些指定的视图。
+   */
+  overrideRenderTarget?: {
+    colorViews: (ITextureView | null)[];
+    depthStencilView?: ITextureView | null;
+  };
+
+  /**
+   * 自定义 RenderPassDescriptor 的属性，例如清除值、加载/存储操作。
+   * 这将与从 renderTarget 或 overrideRenderTarget 派生的描述符合并。
+   */
+  customPassDescriptor?: Partial<RenderPassDescriptor>;
+}
 
 /**
  * 渲染通道接口 - 定义渲染通道流程

--- a/packages/core/src/interface/index.ts
+++ b/packages/core/src/interface/index.ts
@@ -1,13 +1,18 @@
-export * from './IBuffer';
-export * from './IPipelineContext';
-export * from './IRHIDevice';
+export * from './rhi'; // New RHI Abstractions entry point
+
+export * from './IGraphicsDevice';
 export * from './IRenderer';
 export * from './IRenderPass';
-export * from './IRenderTarget';
-export * from './IShader';
-export * from './ITexture';
-export * from './IUniformBuffer';
-export * from './IRenderState';
 export * from './IRenderStats';
-export * from './IResourceFactory';
-export * from './constants';
+export * from './constants'; // Keep engine-specific constants
+
+// Comment out old interfaces that will be replaced/deleted
+// export * from './IBuffer';
+// export * from './IPipelineContext';
+// export * from './IRHIDevice'; // Likely fully replaced by IGraphicsDevice + RHI types
+// export * from './IRenderTarget';
+// export * from './IShader';
+// export * from './ITexture';
+// export * from './IUniformBuffer';
+// export * from './IRenderState';
+// export * from './IResourceFactory'; // Already deleted

--- a/packages/core/src/interface/rhi/index.ts
+++ b/packages/core/src/interface/rhi/index.ts
@@ -1,0 +1,8 @@
+/**
+ * RHI (Rendering Hardware Interface) Abstractions Entry Point
+ */
+
+export * from './rhiEnums';
+export * from './rhiResources';
+export * from './rhiInfos';
+export * from './rhiPipelineStates';

--- a/packages/core/src/interface/rhi/rhiBufferDescriptor.ts
+++ b/packages/core/src/interface/rhi/rhiBufferDescriptor.ts
@@ -1,0 +1,117 @@
+
+/**
+   * 缓冲区描述符
+   */
+export interface RHIBufferDescriptor {
+  /**
+     * 缓冲区字节大小
+     */
+  size: number,
+
+  /**
+     * 缓冲区用途
+     */
+  usage: RHIBufferUsage,
+
+  /**
+     * 初始数据，如果提供则在创建时填充
+     */
+  initialData?: BufferSource,
+
+  /**
+     * WebGL兼容性选项：使用方式提示
+     * 在WebGPU中被忽略
+     */
+  hint?: 'static' | 'dynamic' | 'stream',
+}
+
+/**
+   * 纹理描述符
+   */
+export interface RHITextureDescriptor {
+  /**
+     * 纹理宽度
+     */
+  width: number,
+
+  /**
+     * 纹理高度
+     */
+  height: number,
+
+  /**
+     * 纹理深度或数组层数
+     */
+  depthOrArrayLayers?: number,
+
+  /**
+     * MIP等级数
+     */
+  mipLevelCount?: number,
+
+  /**
+     * 纹理格式
+     */
+  format: RHITextureFormat,
+
+  /**
+     * 纹理用途
+     */
+  usage: RHITextureUsage,
+
+  /**
+     * 采样数量(多重采样)
+     */
+  sampleCount?: number,
+
+  /**
+     * WebGL兼容性选项：纹理类型
+     * 在WebGPU中根据其他属性推断
+     */
+  dimension?: '1d' | '2d' | '3d' | 'cube',
+}
+
+/**
+   * 渲染管线描述符
+   */
+export interface RHIRenderPipelineDescriptor {
+  /**
+     * 顶点着色器
+     */
+  vertexShader: IRHIShaderModule,
+
+  /**
+     * 片段着色器
+     */
+  fragmentShader: IRHIShaderModule,
+
+  /**
+     * 顶点输入布局
+     */
+  vertexLayout: RHIVertexLayout,
+
+  /**
+     * 图元类型
+     */
+  primitiveTopology: RHIPrimitiveTopology,
+
+  /**
+     * 光栅化状态
+     */
+  rasterizationState?: RHIRasterizationState,
+
+  /**
+     * 深度模板状态
+     */
+  depthStencilState?: RHIDepthStencilState,
+
+  /**
+     * 颜色混合状态
+     */
+  colorBlendState?: RHIColorBlendState,
+
+  /**
+     * 绑定组布局
+     */
+  bindGroupLayouts: IRHIBindGroupLayout[],
+}

--- a/packages/core/src/interface/rhi/rhiCommandContent.ts
+++ b/packages/core/src/interface/rhi/rhiCommandContent.ts
@@ -1,0 +1,40 @@
+/**
+ * 渲染命令上下文
+ * 抽象WebGL立即模式和WebGPU命令缓冲区模式的差异
+ */
+export interface IRHICommandContext {
+  /**
+     * 开始渲染通道
+     * @param descriptor 渲染通道描述
+     */
+  beginRenderPass(descriptor: RHIRenderPassDescriptor): IRHIRenderPass,
+
+  /**
+     * 结束当前命令上下文，准备提交
+     * 在WebGPU中生成命令缓冲区，在WebGL中为空操作
+     */
+  finish(): IRHICommandList,
+
+  /**
+     * 更新缓冲区内容
+     * 在WebGL中直接更新，在WebGPU中记录写入命令
+     */
+  updateBuffer(buffer: IRHIBuffer, data: BufferSource, offset?: number): void,
+
+  /**
+     * 更新纹理内容
+     * @param texture 目标纹理
+     * @param data 纹理数据
+     * @param layout 数据布局
+     */
+  updateTexture(
+    texture: IRHITexture,
+    data: BufferSource,
+    layout: RHITextureDataLayout
+  ): void,
+
+  /**
+     * 在设备丢失时清理上下文
+     */
+  release(): void,
+}

--- a/packages/core/src/interface/rhi/rhiDevice.ts
+++ b/packages/core/src/interface/rhi/rhiDevice.ts
@@ -1,0 +1,71 @@
+import type { RHIBackend } from './rhiEnums';
+
+/**
+ * 图形设备接口
+ * 提供对底层图形API的抽象访问
+ */
+export interface IRHIDevice {
+  /**
+   * 获取当前图形后端类型
+   */
+  readonly backend: RHIBackend,
+
+  /**
+   * 创建命令上下文
+   * 在WebGL中为空操作，在WebGPU中创建真正的命令编码器
+   */
+  createCommandContext(): IRHICommandContext,
+
+  /**
+   * 提交渲染命令
+   * 在WebGL中为空操作(已立即执行)，在WebGPU中真正提交命令缓冲区
+   */
+  submitCommands(commands: IRHICommandList): void,
+
+  /**
+   * 创建缓冲区资源
+   * @param descriptor 缓冲区描述
+   */
+  createBuffer(descriptor: RHIBufferDescriptor): IRHIBuffer,
+
+  /**
+   * 创建纹理资源
+   * @param descriptor 纹理描述
+   */
+  createTexture(descriptor: RHITextureDescriptor): IRHITexture,
+
+  /**
+   * 创建着色器模块
+   * @param descriptor 着色器描述
+   */
+  createShaderModule(descriptor: RHIShaderModuleDescriptor): IRHIShaderModule,
+
+  /**
+   * 创建渲染管线
+   * @param descriptor 管线描述
+   */
+  createRenderPipeline(descriptor: RHIRenderPipelineDescriptor): IRHIRenderPipeline,
+
+  /**
+   * 创建采样器
+   * @param descriptor 采样器描述
+   */
+  createSampler(descriptor: RHISamplerDescriptor): IRHISampler,
+
+  /**
+   * 创建绑定组布局
+   * @param descriptor 绑定组布局描述
+   */
+  createBindGroupLayout(descriptor: RHIBindGroupLayoutDescriptor): IRHIBindGroupLayout,
+
+  /**
+   * 创建绑定组
+   * @param descriptor 绑定组描述
+   */
+  createBindGroup(descriptor: RHIBindGroupDescriptor): IRHIBindGroup,
+
+  /**
+   * 设备销毁
+   */
+  destroy(): void,
+}

--- a/packages/core/src/interface/rhi/rhiEnums.ts
+++ b/packages/core/src/interface/rhi/rhiEnums.ts
@@ -1,0 +1,294 @@
+/**
+ * rhiEnums.ts
+ * 包含所有RHI相关的枚举定义。
+ */
+
+//---------------------------------------------------------------------------------------------------------------------
+// 枚举 (Enums)
+//---------------------------------------------------------------------------------------------------------------------
+
+/**
+ * 缓冲区用途标志
+ */
+export enum BufferUsage {
+  None = 0,
+  MapRead = 1 << 0,      // CPU 可读
+  MapWrite = 1 << 1,     // CPU 可写
+  CopySrc = 1 << 2,      // 可作为拷贝源
+  CopyDst = 1 << 3,      // 可作为拷贝目标
+  Index = 1 << 4,        // 索引缓冲区
+  Vertex = 1 << 5,       // 顶点缓冲区
+  Uniform = 1 << 6,      // Uniform缓冲区 (UBO)
+  Storage = 1 << 7,      // 存储缓冲区 (SSBO)
+  Indirect = 1 << 8,     // 间接绘制/派发参数
+  QueryResolve = 1 << 9, // 查询结果
+}
+
+/**
+ * 纹理维度
+ */
+export enum TextureDimension {
+  D1 = '1d',
+  D2 = '2d',
+  D3 = '3d',
+}
+
+/**
+ * 纹理视图维度
+ */
+export enum TextureViewDimension {
+  D1 = '1d',
+  D2 = '2d',
+  D2Array = '2d-array',
+  Cube = 'cube',
+  CubeArray = 'cube-array',
+  D3 = '3d',
+}
+
+/**
+ * 纹理类型 (更接近 WebGPU 的 TextureDimension)
+ */
+export enum TextureType {
+  Texture1D = '1d',
+  Texture2D = '2d',
+  Texture3D = '3d',
+}
+
+/**
+ * 纹理格式
+ */
+export enum TextureFormat {
+  // 8-bit formats
+  R8Unorm = 'r8unorm',
+  R8Snorm = 'r8snorm',
+  R8Uint = 'r8uint',
+  R8Sint = 'r8sint',
+
+  // 16-bit formats
+  R16Uint = 'r16uint',
+  R16Sint = 'r16sint',
+  R16Float = 'r16float',
+  RG8Unorm = 'rg8unorm',
+  RG8Snorm = 'rg8snorm',
+  RG8Uint = 'rg8uint',
+  RG8Sint = 'rg8sint',
+
+  // 32-bit formats
+  R32Uint = 'r32uint',
+  R32Sint = 'r32sint',
+  R32Float = 'r32float',
+  RG16Uint = 'rg16uint',
+  RG16Sint = 'rg16sint',
+  RG16Float = 'rg16float',
+  RGBA8Unorm = 'rgba8unorm',
+  RGBA8UnormSrgb = 'rgba8unorm-srgb',
+  RGBA8Snorm = 'rgba8snorm',
+  RGBA8Uint = 'rgba8uint',
+  RGBA8Sint = 'rgba8sint',
+  BGRA8Unorm = 'bgra8unorm',
+  BGRA8UnormSrgb = 'bgra8unorm-srgb',
+
+  // Packed 32-bit formats
+  RGB9E5Ufloat = 'rgb9e5ufloat',
+  RGB10A2Unorm = 'rgb10a2unorm',
+  RG11B10Ufloat = 'rg11b10ufloat',
+
+  // 64-bit formats
+  RG32Uint = 'rg32uint',
+  RG32Sint = 'rg32sint',
+  RG32Float = 'rg32float',
+  RGBA16Uint = 'rgba16uint',
+  RGBA16Sint = 'rgba16sint',
+  RGBA16Float = 'rgba16float',
+
+  // 128-bit formats
+  RGBA32Uint = 'rgba32uint',
+  RGBA32Sint = 'rgba32sint',
+  RGBA32Float = 'rgba32float',
+
+  // Depth/stencil formats
+  Stencil8 = 'stencil8',
+  Depth16Unorm = 'depth16unorm',
+  Depth24Plus = 'depth24plus',
+  Depth24PlusStencil8 = 'depth24plus-stencil8',
+  Depth32Float = 'depth32float',
+  Depth32FloatStencil8 = 'depth32float-stencil8', // WebGPU specific
+
+  // BC compressed formats (DXT)
+  BC1RGBAUnorm = 'bc1-rgba-unorm',
+  BC1RGBAUnormSrgb = 'bc1-rgba-unorm-srgb',
+  BC2RGBAUnorm = 'bc2-rgba-unorm',
+  BC2RGBAUnormSrgb = 'bc2-rgba-unorm-srgb',
+  BC3RGBAUnorm = 'bc3-rgba-unorm',
+  BC3RGBAUnormSrgb = 'bc3-rgba-unorm-srgb',
+  BC4RUnorm = 'bc4-r-unorm',
+  BC4RSnorm = 'bc4-r-snorm',
+  BC5RGUnorm = 'bc5-rg-unorm',
+  BC5RGSnorm = 'bc5-rg-snorm',
+  BC6HRGBUfloat = 'bc6h-rgb-ufloat',
+  BC6HRGBFloat = 'bc6h-rgb-float',
+  BC7RGBAUnorm = 'bc7-rgba-unorm',
+  BC7RGBAUnormSrgb = 'bc7-rgba-unorm-srgb',
+
+  // ETC2/EAC compressed formats
+  ETC2RGB8Unorm = 'etc2-rgb8unorm',
+  ETC2RGB8UnormSrgb = 'etc2-rgb8unorm-srgb',
+  ETC2RGB8A1Unorm = 'etc2-rgb8a1unorm',
+  ETC2RGB8A1UnormSrgb = 'etc2-rgb8a1unorm-srgb',
+  ETC2RGBA8Unorm = 'etc2-rgba8unorm',
+  ETC2RGBA8UnormSrgb = 'etc2-rgba8unorm-srgb',
+  EACR11Unorm = 'eac-r11unorm',
+  EACR11Snorm = 'eac-r11snorm',
+  EACRG11Unorm = 'eac-rg11unorm',
+  EACRG11Snorm = 'eac-rg11snorm',
+
+  // ASTC compressed formats
+  ASTC4x4Unorm = 'astc-4x4-unorm',
+  ASTC4x4UnormSrgb = 'astc-4x4-unorm-srgb',
+  // ... (add more ASTC formats as needed)
+}
+
+/**
+ * 纹理用途标志 (WebGPU style)
+ */
+export enum TextureUsageFlags {
+  None = 0,
+  CopySrc = 1 << 0,
+  CopyDst = 1 << 1,
+  TextureBinding = 1 << 2, // TextureBinding / Sampled in WebGPU, combines Sampled + InputAttachment in Vulkan
+  StorageBinding = 1 << 3, // Storage image
+  RenderAttachment = 1 << 4, // Color attachment, depth/stencil attachment, resolve attachment
+}
+
+export enum AddressMode {
+  Repeat = 'repeat',
+  ClampToEdge = 'clamp-to-edge',
+  MirrorRepeat = 'mirror-repeat',
+}
+
+export enum FilterMode {
+  Nearest = 'nearest',
+  Linear = 'linear',
+}
+
+export enum CompareFunction {
+  Never = 'never',
+  Less = 'less',
+  Equal = 'equal',
+  LessEqual = 'less-equal',
+  Greater = 'greater',
+  NotEqual = 'not-equal',
+  GreaterEqual = 'greater-equal',
+  Always = 'always',
+}
+
+export enum PrimitiveType {
+  PointList = 'point-list',
+  LineList = 'line-list',
+  LineStrip = 'line-strip',
+  TriangleList = 'triangle-list',
+  TriangleStrip = 'triangle-strip',
+}
+
+export enum IndexFormat {
+  Uint16 = 'uint16',
+  Uint32 = 'uint32',
+}
+
+export enum ShaderStage {
+  Vertex = 1 << 0,
+  Fragment = 1 << 1,
+  Compute = 1 << 2,
+}
+
+export enum BlendFactor {
+  Zero = 'zero',
+  One = 'one',
+  Src = 'src',
+  OneMinusSrc = 'one-minus-src',
+  SrcAlpha = 'src-alpha',
+  OneMinusSrcAlpha = 'one-minus-src-alpha',
+  Dst = 'dst',
+  OneMinusDst = 'one-minus-dst',
+  DstAlpha = 'dst-alpha',
+  OneMinusDstAlpha = 'one-minus-dst-alpha',
+  SrcAlphaSaturated = 'src-alpha-saturated',
+  Constant = 'constant',
+  OneMinusConstant = 'one-minus-constant',
+}
+
+export enum BlendOperation {
+  Add = 'add',
+  Subtract = 'subtract',
+  ReverseSubtract = 'reverse-subtract',
+  Min = 'min',
+  Max = 'max',
+}
+
+export enum StencilOperation {
+  Keep = 'keep',
+  Zero = 'zero',
+  Replace = 'replace',
+  IncrementClamp = 'increment-clamp',
+  DecrementClamp = 'decrement-clamp',
+  Invert = 'invert',
+  IncrementWrap = 'increment-wrap',
+  DecrementWrap = 'decrement-wrap',
+}
+
+export enum CullMode {
+  None = 'none',
+  Front = 'front',
+  Back = 'back',
+}
+
+export enum FrontFace {
+  CCW = 'ccw',
+  CW = 'cw',
+}
+
+export enum VertexFormat {
+  Uint8x2 = 'uint8x2',
+  Uint8x4 = 'uint8x4',
+  Sint8x2 = 'sint8x2',
+  Sint8x4 = 'sint8x4',
+  Unorm8x2 = 'unorm8x2',
+  Unorm8x4 = 'unorm8x4',
+  Snorm8x2 = 'snorm8x2',
+  Snorm8x4 = 'snorm8x4',
+  Uint16x2 = 'uint16x2',
+  Uint16x4 = 'uint16x4',
+  Sint16x2 = 'sint16x2',
+  Sint16x4 = 'sint16x4',
+  Unorm16x2 = 'unorm16x2',
+  Unorm16x4 = 'unorm16x4',
+  Snorm16x2 = 'snorm16x2',
+  Snorm16x4 = 'snorm16x4',
+  Float16x2 = 'float16x2',
+  Float16x4 = 'float16x4',
+  Float32 = 'float32',
+  Float32x2 = 'float32x2',
+  Float32x3 = 'float32x3',
+  Float32x4 = 'float32x4',
+  Uint32 = 'uint32',
+  Uint32x2 = 'uint32x2',
+  Uint32x3 = 'uint32x3',
+  Uint32x4 = 'uint32x4',
+  Sint32 = 'sint32',
+  Sint32x2 = 'sint32x2',
+  Sint32x3 = 'sint32x3',
+  Sint32x4 = 'sint32x4',
+}
+
+export enum MapMode {
+  Read = 1, // Corresponds to WebGPU GPUMapMode.READ
+  Write = 2, // Corresponds to WebGPU GPUMapMode.WRITE
+}
+
+export enum BindGroupLayoutEntryType {
+  Sampler = 'sampler',
+  Texture = 'texture',
+  StorageTexture = 'storage-texture',
+  UniformBuffer = 'uniform-buffer',
+  StorageBuffer = 'storage-buffer',
+} 

--- a/packages/core/src/interface/rhi/rhiInfos.ts
+++ b/packages/core/src/interface/rhi/rhiInfos.ts
@@ -1,0 +1,123 @@
+/**
+ * rhiInfos.ts
+ * 包含用于创建或描述RHI资源及操作的 "Info" 对象/描述符。
+ */
+
+import type { Color } from '@maxellabs/math';
+import type {
+  BufferUsage,
+  TextureViewDimension,
+  TextureType,
+  TextureFormat,
+  TextureUsageFlags,
+  AddressMode,
+  FilterMode,
+  CompareFunction,
+} from './rhiEnums';
+import type { ITextureView } from './rhiResources';
+
+//---------------------------------------------------------------------------------------------------------------------
+// 资源描述符 (Info Objects)
+//---------------------------------------------------------------------------------------------------------------------
+
+export interface BufferInfo {
+  usage: BufferUsage, // Bitwise OR of BufferUsage flags
+  size: number, // in bytes
+  mappedAtCreation?: boolean, // If true, the buffer is mapped at creation (WebGPU)
+  label?: string,
+}
+
+export interface TextureViewDescriptor {
+  label?: string,
+  format?: TextureFormat,
+  dimension?: TextureViewDimension,
+  aspect?: 'all' | 'stencil-only' | 'depth-only', // Default 'all'
+  baseMipLevel?: number, // Default 0
+  mipLevelCount?: number, // Default to remaining levels
+  baseArrayLayer?: number, // Default 0
+  arrayLayerCount?: number, // Default to remaining layers
+}
+
+export interface TextureInfo {
+  type: TextureType, // Effectively dimension: '1d', '2d', '3d'
+  format: TextureFormat,
+  usage: TextureUsageFlags, // Bitwise OR of TextureUsageFlags
+  width: number,
+  height: number,
+  depthOrArrayLayers?: number, // Default 1
+  mipLevelCount?: number, // Default 1
+  sampleCount?: number, // Default 1 (for MSAA)
+  label?: string,
+  viewFormats?: TextureFormat[], // For creating views with different compatible formats (WebGPU)
+}
+
+export interface SamplerInfo {
+  addressModeU?: AddressMode,
+  addressModeV?: AddressMode,
+  addressModeW?: AddressMode,
+  magFilter?: FilterMode,
+  minFilter?: FilterMode,
+  mipmapFilter?: FilterMode, // 'nearest', 'linear', or not set
+  lodMinClamp?: number,
+  lodMaxClamp?: number,
+  compareFunction?: CompareFunction,
+  maxAnisotropy?: number, // 通常 1, 2, 4, 8, 16
+  label?: string,
+}
+
+export interface ShaderModuleInfo {
+  code: string, // WGSL or GLSL source. For GLSL, specific preprocessor defines might indicate stage.
+  entryPoint?: string, // Required for WGSL, ignored for GLSL (uses main())
+  hints?: Record<string, any>, // WebGPU layout hints
+  label?: string,
+}
+
+export interface ShaderInfo {
+  // For WebGL-like single program object
+  vertexSource?: string,
+  fragmentSource?: string,
+  // For WebGPU-like pipeline stages
+  vertexStage?: ShaderModuleInfo,
+  fragmentStage?: ShaderModuleInfo,
+  computeStage?: ShaderModuleInfo,
+  label?: string,
+}
+
+export interface ColorAttachmentInfo { // WebGPU GPURenderPassColorAttachment
+  view: ITextureView,
+  resolveTarget?: ITextureView,
+  clearValue?: Color | [number, number, number, number], // Allow Color type or raw array
+  loadOp: 'load' | 'clear',
+  storeOp: 'store' | 'discard',
+}
+
+export interface DepthStencilAttachmentInfo { // WebGPU GPURenderPassDepthStencilAttachment
+  view: ITextureView,
+  depthClearValue?: number,
+  depthLoadOp?: 'load' | 'clear',
+  depthStoreOp?: 'store' | 'discard',
+  depthReadOnly?: boolean,
+  stencilClearValue?: number,
+  stencilLoadOp?: 'load' | 'clear',
+  stencilStoreOp?: 'store' | 'discard',
+  stencilReadOnly?: boolean,
+}
+
+/**
+ * Describes a render pass (set of attachments).
+ * Similar to a WebGPU RenderPassDescriptor, but TextureViews are ITextureView.
+ */
+export interface RenderPassDescriptor {
+  colorAttachments: ColorAttachmentInfo[],
+  depthStencilAttachment?: DepthStencilAttachmentInfo,
+  occlusionQuerySet?: any, // Placeholder for IOcclusionQuerySet
+  timestampWrites?: any[], // Placeholder for GPURenderPassTimestampWrite[]
+  label?: string,
+}
+
+// IRenderTarget now more aligned with a WebGL FBO concept or a collection of views for a pass
+export interface RenderTargetInfo {
+  colorViews: ITextureView[],
+  depthStencilView?: ITextureView,
+  label?: string,
+}

--- a/packages/core/src/interface/rhi/rhiPipelineStates.ts
+++ b/packages/core/src/interface/rhi/rhiPipelineStates.ts
@@ -1,0 +1,109 @@
+/**
+ * rhiPipelineStates.ts
+ * 包含与RHI渲染管线状态相关的描述符。
+ */
+
+import type {
+  TextureFormat,
+  BlendOperation,
+  BlendFactor,
+  CompareFunction,
+  StencilOperation,
+  FrontFace,
+  CullMode,
+  VertexFormat,
+  IndexFormat,
+  PrimitiveType,
+  ShaderStage,
+  BindGroupLayoutEntryType,
+} from './rhiEnums';
+import type { IShader, IPipelineLayout } from './rhiResources';
+
+//---------------------------------------------------------------------------------------------------------------------
+// 管线状态描述符 (Pipeline State Descriptors)
+//---------------------------------------------------------------------------------------------------------------------
+
+export interface BlendComponentState {
+  operation?: BlendOperation, // Default 'add'
+  srcFactor?: BlendFactor,  // Default 'one'
+  dstFactor?: BlendFactor,  // Default 'zero'
+}
+
+export interface BlendStateInfo { // WebGPU GPUBlendState
+  color: BlendComponentState,
+  alpha: BlendComponentState,
+}
+
+export interface StencilFaceState { // WebGPU GPUStencilFaceState
+  compare?: CompareFunction,      // Default 'always'
+  failOp?: StencilOperation,      // Default 'keep'
+  depthFailOp?: StencilOperation, // Default 'keep'
+  passOp?: StencilOperation,      // Default 'keep'
+}
+
+export interface DepthStencilStateInfo { // WebGPU GPUDepthStencilState
+  format: TextureFormat, // Must match the depth/stencil attachment's format
+  depthWriteEnabled?: boolean,
+  depthCompare?: CompareFunction,
+  stencilFront?: StencilFaceState,
+  stencilBack?: StencilFaceState,
+  stencilReadMask?: number, // Default 0xFFFFFFFF
+  stencilWriteMask?: number, // Default 0xFFFFFFFF
+  depthBias?: number, // Default 0
+  depthBiasSlopeScale?: number, // Default 0
+  depthBiasClamp?: number, // Default 0
+}
+
+export interface RasterizerStateInfo { // Corresponds to parts of WebGPU GPUPrimitiveState
+  frontFace?: FrontFace,   // Default 'ccw'
+  cullMode?: CullMode,     // Default 'none'
+  // depthBias, depthBiasSlopeScale, depthBiasClamp are in DepthStencilState in WebGPU
+  // unclippedDepth?: boolean; // WebGPU
+}
+
+export interface VertexAttribute {
+  format: VertexFormat,
+  offset: number, // Relative to containing VertexBufferLayout's arrayStride
+  shaderLocation: number, // Matches `layout(location = X)` in shader
+}
+
+export interface VertexBufferLayout { // WebGPU GPUVertexBufferLayout
+  arrayStride: number, // Bytes
+  stepMode?: 'vertex' | 'instance', // Default 'vertex'
+  attributes: VertexAttribute[],
+}
+
+export interface BindGroupLayoutEntry {
+  binding: number,
+  visibility: ShaderStage, // Bitwise OR of ShaderStage flags
+  type: BindGroupLayoutEntryType,
+  // Specific members per type, e.g.:
+  // resource?: ITextureView | ISampler | IBufferBinding;
+  // hasDynamicOffset?: boolean; (for uniform/storage buffers)
+  // viewDimension?: TextureViewDimension; (for texture)
+  // sampleType?: TextureSampleType; (for texture)
+  // storageTextureAccess?: 'write-only' | 'read-only' | 'read-write'; (for storage texture)
+  label?: string,
+}
+
+export interface PipelineStateInfo { // WebGPU GPURenderPipelineDescriptor
+  layout: IPipelineLayout | 'auto', // 'auto' to infer from shader
+  vertexStage: { module: IShader, entryPoint: string, constants?: Record<string, number> },
+  fragmentStage?: { module: IShader, entryPoint: string, constants?: Record<string, number>, targets: BlendStateInfo[] }, // targets: one BlendState per color attachment
+  computeStage?: { module: IShader, entryPoint: string, constants?: Record<string, number> },
+  primitiveState?: { // WebGPU GPUPrimitiveState
+    topology?: PrimitiveType, // Default 'triangle-list'
+    stripIndexFormat?: IndexFormat, // For triangle/line strips
+    frontFace?: FrontFace, // Default 'ccw'
+    cullMode?: CullMode, // Default 'none'
+    // unclippedDepth?: boolean; // requires 'depth-clip-control' feature
+  },
+  vertexBuffers?: VertexBufferLayout[], // Describes vertex input (GPUVertexState in WebGPU spec)
+  depthStencilState?: DepthStencilStateInfo,
+  multisampleState?: { // WebGPU GPUMultisampleState
+    count?: number, // Default 1
+    mask?: number,  // Default 0xFFFFFFFF
+    alphaToCoverageEnabled?: boolean, // Default false
+  },
+  label?: string,
+}

--- a/packages/core/src/interface/rhi/rhiRederPass.ts
+++ b/packages/core/src/interface/rhi/rhiRederPass.ts
@@ -1,0 +1,47 @@
+/**
+ * 渲染通道接口
+ * 表示一次渲染操作序列
+ */
+export interface IRHIRenderPass {
+  /**
+     * 设置渲染管线
+     */
+  setPipeline(pipeline: IRHIRenderPipeline): void,
+
+  /**
+     * 设置索引缓冲区
+     */
+  setIndexBuffer(buffer: IRHIBuffer, indexFormat: RHIIndexFormat): void,
+
+  /**
+     * 设置顶点缓冲区
+     */
+  setVertexBuffer(slot: number, buffer: IRHIBuffer, offset?: number): void,
+
+  /**
+     * 设置绑定组
+     */
+  setBindGroup(slot: number, bindGroup: IRHIBindGroup): void,
+
+  /**
+     * 绘制几何体
+     */
+  draw(vertexCount: number, instanceCount?: number, firstVertex?: number, firstInstance?: number): void,
+
+  /**
+     * 使用索引绘制几何体
+     */
+  drawIndexed(
+    indexCount: number,
+    instanceCount?: number,
+    firstIndex?: number,
+    baseVertex?: number,
+    firstInstance?: number
+  ): void,
+
+  /**
+     * 结束渲染通道
+     * 在WebGPU中关闭编码器，在WebGL中更新状态
+     */
+  end(): void,
+}

--- a/packages/core/src/interface/rhi/rhiResources.ts
+++ b/packages/core/src/interface/rhi/rhiResources.ts
@@ -1,0 +1,103 @@
+/**
+ * rhiResources.ts
+ * 包含所有RHI资源接口定义。
+ */
+
+import type {
+  BufferUsage,
+  TextureType,
+  TextureFormat,
+  TextureUsageFlags,
+  AddressMode,
+  FilterMode,
+  CompareFunction,
+  MapMode,
+} from './rhiEnums';
+import type { TextureViewDescriptor } from './rhiInfos'; // Will create rhiInfos.ts later
+
+//---------------------------------------------------------------------------------------------------------------------
+// 资源接口定义
+//---------------------------------------------------------------------------------------------------------------------
+
+export interface RHIResource {
+  readonly label?: string,
+  destroy(): void,
+}
+
+export interface IBuffer extends RHIResource {
+  readonly usage: BufferUsage,
+  readonly size: number,
+  mapAsync(mode: MapMode, offset?: number, size?: number): Promise<ArrayBuffer>,
+  unmap(): void,
+  getMappedRange(offset?: number, size?: number): ArrayBuffer, // Call only when mapped
+}
+
+export interface ITextureView extends RHIResource {
+  readonly texture: ITexture, // Cyclic dependency: ITexture will also refer to ITextureView
+  readonly descriptor: TextureViewDescriptor,
+}
+
+export interface ITexture extends RHIResource {
+  readonly type: TextureType,
+  readonly format: TextureFormat,
+  readonly usage: TextureUsageFlags,
+  readonly width: number,
+  readonly height: number,
+  readonly depthOrArrayLayers: number,
+  readonly mipLevelCount: number,
+  readonly sampleCount: number,
+  createView(descriptor?: TextureViewDescriptor): ITextureView,
+}
+
+export interface ISampler extends RHIResource {
+  // Sampler state is typically immutable after creation
+  readonly addressModeU: AddressMode,
+  readonly addressModeV: AddressMode,
+  readonly addressModeW: AddressMode,
+  readonly magFilter: FilterMode,
+  readonly minFilter: FilterMode,
+  readonly mipmapFilter?: FilterMode,
+  readonly lodMinClamp: number,
+  readonly lodMaxClamp: number,
+  readonly compareFunction?: CompareFunction,
+  readonly maxAnisotropy: number,
+}
+
+/**
+ * Represents a single shader module (e.g., a WGSL module, or a GLSL vertex/fragment shader text)
+ */
+export interface IShaderModule extends RHIResource {
+  // readonly code: string; // Might not be needed if compiled
+  // readonly entryPoint?: string;
+}
+
+/**
+ * RHI 着色器程序对象 or a collection of shader stages for pipeline creation.
+ * For WebGL, this would be a linked GLProgram.
+ * For WebGPU, this might just be a collection of IShaderModule references to be used in PipelineStateInfo.
+ */
+export interface IShader extends RHIResource {
+  // For WebGL: a linked program. For WebGPU: more of a descriptor/collection of modules.
+  // Consider if this interface is strictly necessary or if PipelineStateInfo directly takes ShaderModuleInfo.
+}
+
+export interface IRenderTarget extends RHIResource {
+  // This interface might be more WebGL FBO like.
+  // WebGPU render targets are defined by the views in RenderPassDescriptor.
+  // It could be useful as a helper to manage a set of ITextureViews for a pass.
+  readonly colorViews: ReadonlyArray<ITextureView | null>,
+  readonly depthStencilView: ITextureView | null,
+}
+
+export interface IPipelineState extends RHIResource {
+  // This object represents a compiled, ready-to-use pipeline state.
+  // It would encapsulate all the state from PipelineStateInfo.
+}
+
+export interface IBindGroupLayout extends RHIResource {
+  // readonly entries: ReadonlyArray<BindGroupLayoutEntry>; // BindGroupLayoutEntry will be in rhiPipelineStates.ts
+}
+
+export interface IPipelineLayout extends RHIResource {
+  // readonly bindGroupLayouts: ReadonlyArray<IBindGroupLayout>;
+}

--- a/packages/engine/src/deviceManager.ts
+++ b/packages/engine/src/deviceManager.ts
@@ -1,15 +1,15 @@
-import type { IRHICapabilities, IRHIDevice, RHIDeviceOptions } from '@maxellabs/core';
+import type { IRHICapabilities, RHIDeviceOptions } from '@maxellabs/core';
 import type { RenderAPIType } from '@maxellabs/core';
 import type { GLRenderer } from '@maxellabs/rhi';
 import { GLDevice } from '@maxellabs/rhi';
 
 export class DeviceManager {
   private static instance: DeviceManager;
-  private device: IRHIDevice | null = null;
+  private device: GLDevice | null = null;
 
   private constructor () {}
 
-  public static getInstance (): DeviceManager {
+  static getInstance (): DeviceManager {
     if (!DeviceManager.instance) {
       DeviceManager.instance = new DeviceManager();
     }
@@ -17,7 +17,7 @@ export class DeviceManager {
     return DeviceManager.instance;
   }
 
-  public createDevice (canvas: HTMLCanvasElement, options: RHIDeviceOptions): IRHIDevice {
+  createDevice (canvas: HTMLCanvasElement, options: RHIDeviceOptions): GLDevice {
     if (this.device) {
       return this.device;
     }
@@ -26,42 +26,42 @@ export class DeviceManager {
     return this.device;
   }
 
-  public getDevice (): IRHIDevice | null {
+  getDevice (): GLDevice | null {
     return this.device;
   }
 
-  public resetDevice (): void {
+  resetDevice (): void {
     this.device = null;
   }
-  public getCapabilities (): IRHICapabilities | null {
+  getCapabilities (): IRHICapabilities | null {
     if (!this.device) {
       return null;
     }
 
     return this.device.getCapabilities();
   }
-  public getRenderAPIType (): RenderAPIType {
+  getRenderAPIType (): RenderAPIType {
     if (!this.device) {
       throw new Error('Device not created yet');
     }
 
     return this.device.getRenderAPIType();
   }
-  public getRenderer (): GLRenderer | null {
+  getRenderer (): GLRenderer | null {
     if (!this.device) {
       return null;
     }
 
     return this.device.getRenderer();
   }
-  public getGLContext (): WebGLRenderingContext | WebGL2RenderingContext | null {
+  getGLContext (): WebGLRenderingContext | WebGL2RenderingContext | null {
     if (!this.device) {
       return null;
     }
 
     return this.device.getGLContext();
   }
-  public getGLCapabilities (): IRHICapabilities | null {
+  getGLCapabilities (): IRHICapabilities | null {
     if (!this.device) {
       return null;
     }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,235 +1,73 @@
-import type { Color } from '@maxellabs/math';
-import type {
-  IRHIDevice,
-  Scene } from '@maxellabs/core';
-import {
-  Canvas,
-  EventDispatcher,
-  ObjectPoolManager,
-  ObjectPoolManagerEventType,
-  RenderContext,
-  RendererType,
-  ResourceManager,
-  SceneManager,
-  ShaderMacro,
-  ShaderMacroCollection,
-  Time,
-  Event,
-} from '@maxellabs/core';
+import { IRenderer, RenderContext, RendererOptions, ResourceManager, Scene, SceneManager, Time } from '@maxellabs/core';
+import { Event, EventDispatcher, RenderContext, ResourceManager, SceneManager, Time } from '@maxellabs/core';
+import { Container, ServiceKeys } from 'packages/core/src/base';
+import { RendererFactory } from './renderer/RendererFactory';
 
 /**
- * 引擎配置接口
+ * 引擎配置选项
  */
-export interface EngineOptions {
-  /** 目标画布 */
-  canvas: HTMLCanvasElement,
-  /** 是否使用抗锯齿 */
-  antialias?: boolean,
-  /** 是否启用Alpha通道 */
-  alpha?: boolean,
-  /** 背景颜色 */
-  backgroundColor?: Color,
-  /** 渲染器类型 */
-  rendererType?: RendererType,
-  /** 是否开启HDR */
-  enableHDR?: boolean,
-  /** 是否自动开始渲染循环 */
+export interface EngineOptions extends RendererOptions {
+  /** 目标帧率 */
+  targetFrameRate?: number,
+  /** 是否自动启动引擎 */
   autoStart?: boolean,
-  /** 是否开启性能统计 */
-  enableStats?: boolean,
-  /** 是否自动管理对象池 */
-  enableObjectPoolManager?: boolean,
-  /** 对象池性能分析间隔（毫秒） */
-  objectPoolAnalysisInterval?: number,
+  /** 是否启用物理系统 */
+  enablePhysics?: boolean,
+  /** 是否启用音频系统 */
+  enableAudio?: boolean,
+  /** 是否启用调试模式 */
+  debug?: boolean,
 }
 
 /**
- * 引擎事件类型
+ * 引擎状态枚举
  */
-export enum EngineEventType {
-  /** 引擎初始化完成 */
-  Ready = 'engine-ready',
-  /** 引擎每帧开始 */
-  BeforeUpdate = 'engine-before-update',
-  /** 引擎每帧更新完成 */
-  AfterUpdate = 'engine-after-update',
-  /** 引擎每帧渲染开始 */
-  BeforeRender = 'engine-before-render',
-  /** 引擎每帧渲染完成 */
-  AfterRender = 'engine-after-render',
-  /** 引擎窗口大小改变 */
-  Resize = 'engine-resize',
-  /** 设备丢失 */
-  DeviceLost = 'engine-device-lost',
-  /** 设备恢复 */
-  DeviceRestored = 'engine-device-restored',
-  /** 对象池性能分析 */
-  ObjectPoolAnalysis = 'engine-object-pool-analysis'
+export enum EngineState {
+  /** 未初始化 */
+  UNINITIALIZED,
+  /** 初始化中 */
+  INITIALIZING,
+  /** 运行中 */
+  RUNNING,
+  /** 暂停 */
+  PAUSED,
+  /** 已销毁 */
+  DESTROYED
 }
 
 /**
- * 引擎主类，作为整个引擎的入口点
+ * 3D引擎核心类
+ * 负责管理引擎生命周期、更新循环、场景管理和渲染
  */
 export class Engine extends EventDispatcher {
-  /** @internal 伽马空间着色器宏 */
-  static _gammaMacro: ShaderMacro = ShaderMacro.getByName('ENGINE_IS_COLORSPACE_GAMMA');
-  /** @internal 无深度纹理着色器宏 */
-  static _noDepthTextureMacro: ShaderMacro = ShaderMacro.getByName('ENGINE_NO_DEPTH_TEXTURE');
-  /** @internal 2D空间单位到像素单位的转换系数 */
-  static _pixelsPerUnit: number = 100;
-
-  /** @internal 硬件渲染器 */
-  _hardwareRenderer: IRHIDevice;
-  /** @internal 渲染上下文 */
-  _renderContext: RenderContext;
-  /** @internal 全局着色器宏集合 */
-  _globalShaderMacro: ShaderMacroCollection = new ShaderMacroCollection();
-  /** @internal 渲染次数统计 */
-  _renderCount: number = 0;
-
-  /** @internal */
-  private _canvas: Canvas;
-  /** 资源管理器 */
-  private _resourceManager: ResourceManager;
+  /** IOC容器 */
+  private container: Container;
+  /** 引擎状态 */
+  private state: EngineState = EngineState.UNINITIALIZED;
+  /** 渲染器实例 */
+  private renderer: IRenderer;
   /** 场景管理器 */
-  private _sceneManager: SceneManager;
+  private sceneManager: SceneManager;
+  /** 资源管理器 */
+  private resourceManager: ResourceManager;
+  /** 输入管理器 */
+//   private inputManager: InputManager;
   /** 时间管理器 */
-  private _time: Time = new Time();
-  /** 是否暂停 */
-  private _isPaused: boolean = true;
-  /** 动画帧ID */
-  private _animFrameId: number = 0;
-  /** 帧间隔定时器ID */
-  private _timeoutId: number = 0;
-  /** 垂直同步计数 */
-  private _vSyncCount: number = 1;
-  /** 垂直同步计数器 */
-  private _vSyncCounter: number = 1;
+  private time: Time;
+  /** 渲染上下文 */
+  private renderContext: RenderContext;
   /** 目标帧率 */
-  private _targetFrameRate: number = 60;
-  /** 目标帧间隔（毫秒） */
-  private _targetFrameInterval: number = 1000 / 60;
-  /** 帧处理中标志 */
-  private _frameInProcess: boolean = false;
-  /** 等待销毁标志 */
-  private _waitingDestroy: boolean = false;
-  /** 设备丢失标志 */
-  private _isDeviceLost: boolean = false;
-  /** 性能统计数据 */
-  private _stats = {
-    fps: 0,
-    frameTime: 0,
-    drawCalls: 0,
-    triangles: 0,
-    lastUpdateTime: 0,
-    frames: 0,
-  };
-  /** 是否启用性能统计 */
-  private _enableStats: boolean = false;
-
-  /** 对象池管理器 */
-  readonly objectPoolManager: ObjectPoolManager;
-
-  /** 是否启用对象池管理 */
-  private _enableObjectPoolManager: boolean = false;
-
-  /** 对象池分析间隔 */
-  private _objectPoolAnalysisInterval: number = 30000;
-
-  /**
-   * 动画循环函数
-   */
-  private _animate = () => {
-    if (this._vSyncCount) {
-      // 使用requestAnimationFrame进行同步
-      this._animFrameId = requestAnimationFrame(this._animate);
-      if (this._vSyncCounter++ % this._vSyncCount === 0) {
-        this.update();
-        this._vSyncCounter = 1;
-      }
-    } else {
-      // 使用setTimeout实现自定义帧率
-      this._timeoutId = window.setTimeout(this._animate, this._targetFrameInterval);
-      this.update();
-    }
-  };
-
-  /**
-   * 引擎设置
-   */
-  get settings (): any {
-    return {};
-  }
-
-  /**
-   * 用于渲染的画布
-   */
-  get canvas (): Canvas {
-    return this._canvas;
-  }
-
-  /**
-   * 资源管理器
-   */
-  get resourceManager (): ResourceManager {
-    return this._resourceManager;
-  }
-
-  /**
-   * 场景管理器
-   */
-  get sceneManager (): SceneManager {
-    return this._sceneManager;
-  }
-
-  /**
-   * 引擎时间信息
-   */
-  get time (): Time {
-    return this._time;
-  }
-
-  /**
-   * 引擎是否已暂停
-   */
-  get isPaused (): boolean {
-    return this._isPaused;
-  }
-
-  /**
-   * 垂直同步计数，表示每帧的垂直消隐次数
-   * @remarks 0表示垂直同步已关闭
-   */
-  get vSyncCount (): number {
-    return this._vSyncCount;
-  }
-
-  set vSyncCount (value: number) {
-    this._vSyncCount = Math.max(0, Math.floor(value));
-  }
-
-  /**
-   * 设置要达到的目标帧率
-   * @remarks
-   * 仅当vSyncCount = 0时生效
-   * 值越大，目标帧率越高
-   */
-  get targetFrameRate (): number {
-    return this._targetFrameRate;
-  }
-
-  set targetFrameRate (value: number) {
-    value = Math.max(0.000001, value);
-    this._targetFrameRate = value;
-    this._targetFrameInterval = 1000 / value;
-  }
-
-  /**
-   * 获取性能统计信息
-   */
-  get stats () {
-    return { ...this._stats };
-  }
+  private targetFrameRate: number = 60;
+  /** 上一帧时间戳 */
+  private lastFrameTime: number = 0;
+  /** 是否在运行中 */
+  private isRunning: boolean = false;
+  /** 动画帧请求ID */
+  private animationFrameId: number = 0;
+  /** 引擎配置选项 */
+  private options: EngineOptions;
+  /** 调试模式 */
+  private debugMode: boolean = false;
 
   /**
    * 创建引擎实例
@@ -237,333 +75,325 @@ export class Engine extends EventDispatcher {
    */
   constructor (options: EngineOptions) {
     super();
+    this.options = options;
+    this.targetFrameRate = options.targetFrameRate || 60;
+    this.debugMode = options.debug || false;
+    this.container = Container.getInstance();
 
-    // 创建画布
-    this._canvas = new Canvas(options.canvas);
-
-    // 创建渲染上下文 - 由于循环依赖，需要特殊处理
-    this._renderContext = new RenderContext(this as any);
-
-    // 创建硬件渲染器（从RHI包中导入相应的渲染器）
-    this._hardwareRenderer = this._createRenderer(options);
-
-    // 初始化渲染器
-    this._initializeRenderer(options);
-
-    // 创建资源管理器
-    this._resourceManager = new ResourceManager(this as any);
-
-    // 创建场景管理器
-    this._sceneManager = new SceneManager(this as any);
-
-    // 创建对象池管理器
-    this.objectPoolManager = ObjectPoolManager.getInstance();
-    this._enableObjectPoolManager = options.enableObjectPoolManager !== false;
-
-    if (options.objectPoolAnalysisInterval !== undefined) {
-      this._objectPoolAnalysisInterval = Math.max(1000, options.objectPoolAnalysisInterval);
-    }
-
-    if (this._enableObjectPoolManager) {
-      this.objectPoolManager.enableAutoAnalysis(true, this._objectPoolAnalysisInterval);
-
-      // 监听对象池性能分析事件
-      this.objectPoolManager.on(ObjectPoolManagerEventType.PERFORMANCE_ANALYSIS, (e: any) => {
-        // 转发到引擎事件
-        this.dispatchEvent(new Event(EngineEventType.ObjectPoolAnalysis, false, e));
-      });
-    }
-
-    // 设置统计信息启用状态
-    this._enableStats = options.enableStats || false;
-
-    // 自动启动
-    if (options.autoStart !== false) {
-      this.run();
-    }
-
-    // 派发就绪事件
-    this.dispatchEvent(new Event(EngineEventType.Ready));
+    // 注册自身到IOC容器
+    this.container.register(ServiceKeys.ENGINE, this);
   }
 
   /**
-   * 创建渲染器
-   * @param options 引擎配置选项
-   * @returns 渲染器接口实例
+   * 初始化引擎
+   * @returns Promise<void>
    */
-  private _createRenderer (options: EngineOptions): IRHIDevice {
-    // TODO: 实际应用中，应该根据不同的渲染类型创建不同的渲染器
-    // 这里仅为示例，实际实现需要根据项目中的渲染器实现
+  async initialize (): Promise<void> {
+    if (this.state !== EngineState.UNINITIALIZED) {
+      console.warn('Engine already initialized or initializing');
 
-    // 根据配置选择渲染器类型
-    const rendererType = options.rendererType ?? RendererType.WebGL2;
-
-    // 在实际环境中，应该从RHI包导入相应的渲染器类
-    let _renderer: IRHIDevice;
-
-    switch (rendererType) {
-      case RendererType.WebGL:
-        // 导入WebGL渲染器
-        // _renderer = new WebGLRenderer();
-        break;
-      case RendererType.WebGPU:
-        // 导入WebGPU渲染器
-        // _renderer = new WebGPURenderer();
-        break;
-      case RendererType.WebGL2:
-      default:
-        // 导入WebGL2渲染器
-        // _renderer = new WebGL2Renderer();
-        break;
+      return;
     }
 
-    // 临时返回任意对象作为渲染器接口
-    // 在实际应用中，应该返回真实的渲染器实例
-    return {} as IRHIDevice;
+    this.state = EngineState.INITIALIZING;
+
+    try {
+      // 创建时间管理器
+      this.time = new Time();
+      this.container.register(ServiceKeys.TIME, this.time);
+
+      // 创建渲染上下文
+      this.renderContext = new RenderContext();
+      this.container.register(ServiceKeys.RENDER_CONTEXT, this.renderContext);
+
+      // 创建资源管理器
+      this.resourceManager = new ResourceManager();
+      this.container.register(ServiceKeys.RESOURCE_MANAGER, this.resourceManager);
+
+      // 创建场景管理器
+      this.sceneManager = new SceneManager();
+      this.container.register(ServiceKeys.SCENE_MANAGER, this.sceneManager);
+
+      // 创建输入管理器
+    //   this.inputManager = new InputManager();
+    //   this.container.register(ServiceKeys.INPUT_MANAGER, this.inputManager);
+
+      // 创建渲染器
+      this.renderer = await RendererFactory.createRenderer(this.options);
+
+      // 初始化完成后，自动启动引擎(如果配置了autoStart)
+      if (this.options.autoStart) {
+        this.start();
+      }
+
+      this.state = EngineState.RUNNING;
+
+      // 触发初始化完成事件
+      this.dispatchEvent('initialized');
+    } catch (error) {
+      console.error('Failed to initialize engine:', error);
+      this.state = EngineState.UNINITIALIZED;
+      throw error;
+    }
   }
 
   /**
-   * 初始化渲染器
-   * @param options 引擎配置选项
+   * 启动引擎
    */
-  private _initializeRenderer (options: EngineOptions): void {
-    // 初始化渲染器
-    // 在实际应用中，应该调用渲染器的初始化方法
-    // this._hardwareRenderer.initialize(this._canvas.element, {
-    //   antialias: options.antialias,
-    //   alpha: options.alpha,
-    //   depth: true,
-    //   stencil: true,
-    //   premultipliedAlpha: true,
-    //   preserveDrawingBuffer: false
-    // });
-  }
+  start (): void {
+    if (this.state === EngineState.RUNNING) {
+      return;
+    }
 
-  /**
-   * 创建一个新的场景
-   * @param name 场景名称
-   * @returns 新创建的场景
-   */
-  createScene (name?: string): Scene {
-    return this._sceneManager.createScene(name);
+    if (this.state === EngineState.UNINITIALIZED) {
+      console.warn('Engine not initialized. Call initialize() first.');
+
+      return;
+    }
+
+    this.state = EngineState.RUNNING;
+    this.isRunning = true;
+    this.lastFrameTime = performance.now();
+
+    // 开始主循环
+    this.animationFrameId = requestAnimationFrame(this.mainLoop.bind(this));
+
+    // 触发启动事件
+    this.dispatchEvent('started');
   }
 
   /**
    * 暂停引擎
    */
   pause (): void {
-    if (!this._isPaused) {
-      this._isPaused = true;
-      if (this._animFrameId) {
-        cancelAnimationFrame(this._animFrameId);
-        this._animFrameId = 0;
-      }
-      if (this._timeoutId) {
-        clearTimeout(this._timeoutId);
-        this._timeoutId = 0;
-      }
+    if (this.state !== EngineState.RUNNING) {
+      return;
     }
+
+    this.state = EngineState.PAUSED;
+    this.isRunning = false;
+
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = 0;
+    }
+
+    // 触发暂停事件
+    this.dispatchEvent('paused');
   }
 
   /**
    * 恢复引擎
    */
   resume (): void {
-    if (this._isPaused) {
-      this._isPaused = false;
-      this._time.reset();
-      this._animate();
-    }
-  }
-
-  /**
-   * 更新一帧
-   */
-  update (): void {
-    // 如果帧正在处理中或已销毁，则跳过
-    if (this._frameInProcess || this.destroyed) {
+    if (this.state !== EngineState.PAUSED) {
       return;
     }
 
-    // 标记帧处理中
-    this._frameInProcess = true;
+    this.start();
+  }
 
-    // 更新时间信息
-    this._time.update();
-    const time = this._time.time;
-    const deltaTime = this._time.deltaTime;
+  /**
+   * 引擎主循环
+   */
+  private mainLoop (timestamp: number): void {
+    if (!this.isRunning) {
+      return;
+    }
 
-    // 派发帧开始事件
-    this.dispatchEvent(new Event(EngineEventType.BeforeUpdate));
+    // 计算帧时间
+    const deltaTime = timestamp - this.lastFrameTime;
+    const targetFrameTime = 1000 / this.targetFrameRate;
 
-    // 更新对象池管理器
-    if (this._enableObjectPoolManager) {
-      this.objectPoolManager.update();
+    // 如果时间间隔小于目标帧率时间，则跳过这一帧
+    if (deltaTime < targetFrameTime) {
+      this.animationFrameId = requestAnimationFrame(this.mainLoop.bind(this));
+
+      return;
+    }
+
+    // 更新时间管理器
+    this.time.update(deltaTime);
+
+    // 更新输入管理器
+    // this.inputManager.update();
+
+    // 更新场景和游戏对象
+    this.update(this.time.deltaTime);
+
+    // 渲染场景
+    this.render();
+
+    // 记录当前帧时间
+    this.lastFrameTime = timestamp;
+
+    // 请求下一帧
+    this.animationFrameId = requestAnimationFrame(this.mainLoop.bind(this));
+  }
+
+  /**
+   * 更新场景和所有游戏对象
+   * @param deltaTime 时间差(秒)
+   */
+  private update (deltaTime: number): void {
+    const activeScene = this.sceneManager.activeScene;
+
+    if (!activeScene) {
+      return;
     }
 
     // 更新场景
-    this._sceneManager.update(deltaTime);
+    activeScene.update(deltaTime);
 
-    // 派发帧更新完成事件
-    this.dispatchEvent(new Event(EngineEventType.AfterUpdate));
+    // 触发更新事件
+    this.dispatchEvent('update', { deltaTime });
+  }
+
+  /**
+   * 渲染当前场景
+   */
+  private render (): void {
+    const activeScene = this.sceneManager.activeScene;
+
+    if (!activeScene) {
+      return;
+    }
+
+    // 设置渲染上下文
+    this.renderContext.setScene(activeScene);
 
     // 执行渲染
-    this._render();
+    this.renderer.render();
 
-    // 更新统计信息
-    if (this._enableStats) {
-      this._updateStats(time, deltaTime);
-    }
-
-    // 处理可能的销毁请求
-    if (this._waitingDestroy) {
-      this._destroy();
-    }
-
-    // 标记帧处理完成
-    this._frameInProcess = false;
+    // 触发渲染事件
+    this.dispatchEvent('render');
   }
 
   /**
-   * 开始运行引擎
+   * 设置引擎目标帧率
+   * @param fps 每秒帧数
    */
-  run (): void {
-    this.resume();
+  setTargetFrameRate (fps: number): void {
+    this.targetFrameRate = Math.max(1, fps);
   }
 
   /**
-   * 强制设备丢失
+   * 创建新场景
+   * @param name 场景名称
+   * @returns 新创建的场景
    */
-  forceLoseDevice (): void {
-    if (!this._isDeviceLost) {
-      this._onDeviceLost();
-    }
+  createScene (name?: string): Scene {
+    return this.sceneManager.createScene(name);
   }
 
   /**
-   * 强制设备恢复
+   * 加载场景
+   * @param scene 要加载的场景
    */
-  forceRestoreDevice (): void {
-    if (this._isDeviceLost) {
-      this._onDeviceRestored();
-    }
+  loadScene (scene: Scene): void {
+    this.sceneManager.setActiveScene(scene);
   }
 
   /**
-   * 销毁引擎
+   * 销毁引擎实例
    */
   override destroy (): void {
-    if (this.destroyed) {
+    super.destroy();
+    if (this.state === EngineState.DESTROYED) {
       return;
     }
 
-    if (this._frameInProcess) {
-      this._waitingDestroy = true;
-      return;
-    }
-
-    this._destroy();
-  }
-
-  /**
-   * 调整大小
-   * @param width 宽度
-   * @param height 高度
-   */
-  resize (width: number, height: number): void {
-    this._canvas.resizeByClientSize(width, height);
-    this.dispatchEvent(new Event(EngineEventType.Resize));
-  }
-
-  /**
-   * 内部渲染方法
-   */
-  private _render (): void {
-    this._renderCount++;
-
-    // 派发渲染开始事件
-    this.dispatchEvent(new Event(EngineEventType.BeforeRender));
-
-    const scenes = this._sceneManager.activeScenes;
-
-    for (let i = 0, len = scenes.length; i < len; i++) {
-      const scene = scenes[i];
-      // 渲染场景
-      scene.render();
-    }
-
-    // 派发渲染完成事件
-    this.dispatchEvent(new Event(EngineEventType.AfterRender));
-  }
-
-  /**
-   * 更新性能统计
-   * @param time 当前时间戳
-   * @param deltaTime 帧时间
-   */
-  private _updateStats (time: number, deltaTime: number): void {
-    const stats = this._stats;
-
-    // 更新帧时间
-    stats.frameTime = deltaTime * 1000; // 转换为毫秒
-
-    // 更新帧数
-    stats.frames++;
-
-    // 每秒更新一次FPS计数
-    if (time - stats.lastUpdateTime >= 1000) {
-      stats.fps = stats.frames * 1000 / (time - stats.lastUpdateTime);
-      stats.lastUpdateTime = time;
-      stats.frames = 0;
-
-      // 重置绘制统计
-      stats.drawCalls = 0;
-      stats.triangles = 0;
-    }
-  }
-
-  /**
-   * 内部销毁方法
-   */
-  private _destroy (): void {
+    // 停止主循环
     this.pause();
 
-    // 销毁所有事件监听
-    super.destroy();
+    // 销毁渲染器
+    if (this.renderer) {
+      this.renderer.destroy();
+    }
 
     // 销毁场景管理器
-    this._sceneManager.destroy();
+    if (this.sceneManager) {
+      this.sceneManager.destroy();
+    }
 
     // 销毁资源管理器
-    this._resourceManager.destroy();
-
-    // 销毁硬件渲染器
-    if (this._hardwareRenderer && typeof this._hardwareRenderer.destroy === 'function') {
-      this._hardwareRenderer.destroy();
+    if (this.resourceManager) {
+      this.resourceManager.destroy();
     }
 
-    // 停用对象池管理器
-    if (this._enableObjectPoolManager) {
-      this.objectPoolManager.enableAutoAnalysis(false);
-      this.objectPoolManager.clearAllPools();
-    }
+    // 清空IOC容器
+    this.container.clear();
+
+    this.state = EngineState.DESTROYED;
+
+    // 触发销毁事件
+    this.dispatchEvent('destroyed');
+
+    // 调用父类销毁方法
+    super.destroy();
   }
 
   /**
-   * 设备丢失回调
+   * 获取当前引擎状态
    */
-  private _onDeviceLost (): void {
-    this._isDeviceLost = true;
-    // 发送设备丢失事件
-    this.dispatchEvent(new Event(EngineEventType.DeviceLost));
+  getState (): EngineState {
+    return this.state;
   }
 
   /**
-   * 设备恢复回调
+   * 获取场景管理器
    */
-  private _onDeviceRestored (): void {
-    this._isDeviceLost = false;
-    // 发送设备恢复事件
-    this.dispatchEvent(new Event(EngineEventType.DeviceRestored));
+  getSceneManager (): SceneManager {
+    return this.sceneManager;
+  }
+
+  /**
+   * 获取资源管理器
+   */
+  getResourceManager (): ResourceManager {
+    return this.resourceManager;
+  }
+
+  // /**
+  //  * 获取输入管理器
+  //  */
+  // getInputManager (): InputManager {
+  //   return this.inputManager;
+  // }
+
+  /**
+   * 获取时间管理器
+   */
+  getTime (): Time {
+    return this.time;
+  }
+
+  /**
+   * 获取渲染器
+   */
+  getRenderer (): IRenderer {
+    return this.renderer;
+  }
+
+  /**
+   * 获取渲染上下文
+   */
+  getRenderContext (): RenderContext {
+    return this.renderContext;
+  }
+
+  /**
+   * 是否处于调试模式
+   */
+  isDebugMode (): boolean {
+    return this.debugMode;
+  }
+
+  /**
+   * 设置调试模式
+   * @param enabled 是否启用
+   */
+  setDebugMode (enabled: boolean): void {
+    this.debugMode = enabled;
   }
 }

--- a/packages/engine/src/renderer/RendererFactory.ts
+++ b/packages/engine/src/renderer/RendererFactory.ts
@@ -1,22 +1,21 @@
-import { ServiceKeys, Container } from '../base/IOC';
-import { RendererType } from './RendererType';
+import { RendererType, Container, ServiceKeys } from '@maxellabs/core';
 
 /**
  * 渲染器配置接口
  */
 export interface RendererOptions {
   /** Canvas元素或ID */
-  canvas: HTMLCanvasElement | string;
+  canvas: HTMLCanvasElement | string,
   /** 是否启用抗锯齿 */
-  antialias?: boolean;
+  antialias?: boolean,
   /** 是否启用alpha通道 */
-  alpha?: boolean;
+  alpha?: boolean,
   /** 是否保留缓冲区内容 */
-  preserveDrawingBuffer?: boolean;
+  preserveDrawingBuffer?: boolean,
   /** 首选低功耗GPU */
-  powerPreference?: 'default' | 'high-performance' | 'low-power';
+  powerPreference?: 'default' | 'high-performance' | 'low-power',
   /** 渲染器类型 */
-  type?: RendererType;
+  type?: RendererType,
 }
 
 /**
@@ -24,19 +23,19 @@ export interface RendererOptions {
  */
 export interface IRenderer {
   /** 初始化渲染器 */
-  initialize(options: RendererOptions): Promise<void>;
+  initialize(options: RendererOptions): Promise<void>,
   /** 调整大小 */
-  resize(width: number, height: number): void;
+  resize(width: number, height: number): void,
   /** 渲染一帧 */
-  render(): void;
+  render(): void,
   /** 销毁渲染器 */
-  destroy(): void;
+  destroy(): void,
   /** 渲染器类型 */
-  readonly type: RendererType;
+  readonly type: RendererType,
   /** 画布元素 */
-  readonly canvas: HTMLCanvasElement;
+  readonly canvas: HTMLCanvasElement,
   /** 上下文 */
-  readonly context: any;
+  readonly context: any,
 }
 
 /**
@@ -45,46 +44,46 @@ export interface IRenderer {
  */
 export class RendererFactory {
   private static registeredRenderers: Map<RendererType, new () => IRenderer> = new Map();
-  
+
   /**
    * 注册渲染器类型
    * @param type 渲染器类型
    * @param rendererClass 渲染器类
    */
-  static registerRenderer(type: RendererType, rendererClass: new () => IRenderer): void {
+  static registerRenderer (type: RendererType, rendererClass: new () => IRenderer): void {
     this.registeredRenderers.set(type, rendererClass);
   }
-  
+
   /**
    * 创建渲染器实例
    * @param options 渲染器配置
    * @returns 渲染器实例
    */
-  static async createRenderer(options: RendererOptions): Promise<IRenderer> {
+  static async createRenderer (options: RendererOptions): Promise<IRenderer> {
     const container = Container.getInstance();
     const type = options.type || RendererType.WebGL2;
-    
+
     if (!this.registeredRenderers.has(type)) {
       throw new Error(`Renderer type ${type} is not registered`);
     }
-    
+
     const RendererClass = this.registeredRenderers.get(type)!;
     const renderer = new RendererClass();
-    
+
     await renderer.initialize(options);
-    
+
     // 注册到IOC容器
     container.register(ServiceKeys.RENDERER, renderer);
-    
+
     return renderer;
   }
-  
+
   /**
    * 判断当前环境是否支持指定的渲染器类型
    * @param type 渲染器类型
    * @returns 是否支持
    */
-  static isSupported(type: RendererType): boolean {
+  static isSupported (type: RendererType): boolean {
     switch (type) {
       case RendererType.WebGL:
         return this.isWebGLSupported();
@@ -96,51 +95,60 @@ export class RendererFactory {
         return false;
     }
   }
-  
+
   /**
    * 检测当前环境支持的最佳渲染器类型
    * @returns 最佳渲染器类型
    */
-  static detectBestRenderer(): RendererType {
-    if (this.isWebGPUSupported()) {
-      return RendererType.WebGPU;
-    } else if (this.isWebGL2Supported()) {
+  static detectBestRenderer (): RendererType {
+    if (this.isWebGL2Supported()) {
       return RendererType.WebGL2;
     } else if (this.isWebGLSupported()) {
       return RendererType.WebGL;
+    } else if (this.isWebGPUSupported()) {
+      return RendererType.WebGPU;
     }
-    
+
     throw new Error('Current environment does not support any available renderer');
   }
-  
+
   /**
    * 检测是否支持WebGL
    */
-  private static isWebGLSupported(): boolean {
+  private static isWebGLSupported (): boolean {
     try {
       const canvas = document.createElement('canvas');
+
       return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
     } catch (e) {
+      console.error('WebGL support check failed:', e);
+
       return false;
     }
   }
-  
+
   /**
    * 检测是否支持WebGL2
    */
-  private static isWebGL2Supported(): boolean {
+  private static isWebGL2Supported (): boolean {
     try {
       const canvas = document.createElement('canvas');
+
       return !!(window.WebGL2RenderingContext && canvas.getContext('webgl2'));
     } catch (e) {
+
+      console.error('WebGL2 support check failed:', e);
+
       return false;
     }
   }
-  
+
   /**
    * 检测是否支持WebGPU
    */
-  private static isWebGPUSupported(): boolean {
+  private static isWebGPUSupported (): boolean {
+    // WebGPU的支持检查
+    // @ts-expect-error
     return !!(navigator.gpu && navigator.gpu.requestAdapter);
   }
-} 
+}


### PR DESCRIPTION
- Introduced `rhiPipelineStates.ts` to define various pipeline state descriptors including blend, depth-stencil, rasterizer states, and vertex buffer layouts.
- Created `rhiRenderPass.ts` to define the `IRHIRenderPass` interface for managing rendering operations.
- Added `rhiResources.ts` to encapsulate resource interfaces such as buffers, textures, samplers, and shader modules.
- Updated `deviceManager.ts` to utilize the new GLDevice type instead of IRHIDevice.
- Refactored `engine.ts` to streamline engine initialization and rendering processes, incorporating the new renderer factory.
- Implemented `RendererFactory.ts` to manage the creation and registration of different renderer types.